### PR TITLE
Changed Install_Update to pass a list of parameters instead of a string

### DIFF
--- a/pinginstaller/Install_Update_PINGMapper.py
+++ b/pinginstaller/Install_Update_PINGMapper.py
@@ -45,7 +45,7 @@ def install(conda_key, yml):
     subprocess.run('''"{}" env create --file "{}"'''.format(conda_key, yml), shell=True)
 
     # Install pysimplegui
-    subprocess.run('''"{}" run -n ping pip install --upgrade -i https://PySimpleGUI.net/install PySimpleGUI'''.format(conda_key))
+    subprocess.run([conda_key, 'run', '-n', 'ping', 'pip', 'install', '--upgrade', '-i', 'https://PySimpleGUI.net/install', 'PySimpleGUI'])
 
     # List the environments
     subprocess.run('conda env list', shell=True)
@@ -58,7 +58,7 @@ def update(conda_key, yml):
     subprocess.run('''"{}" env update --file "{}" --prune'''.format(conda_key, yml), shell=True)
 
     # Install pysimplegui
-    subprocess.run('''"{}" run -n ping pip install --upgrade -i https://PySimpleGUI.net/install PySimpleGUI'''.format(conda_key))
+    subprocess.run([conda_key, 'run', '-n', 'ping', 'pip', 'install', '--upgrade', '-i', 'https://PySimpleGUI.net/install', 'PySimpleGUI'])
 
     # List the environments
     subprocess.run('conda env list', shell=True)
@@ -75,7 +75,7 @@ def update_pinginstaller():
     conda_key = get_conda_key()
 
     # Update pinginstaller
-    subprocess.run('''"{}" run -n ping pip install pinginstaller -U'''.format(conda_key))
+    subprocess.run([conda_key, 'run', '-n', 'ping', 'pip', 'install', 'pinginstaller', '-U'])
 
 
 # def install_update(conda_base, conda_key):


### PR DESCRIPTION
Got errors when trying to install PINGInstaller on Mac in Terminal, found the recent issue #2 someone had posted to Github with the Update script and used their solution to edit the Install_Update script. Ran the new version locally and it successfully installed and opened. 

-Neil 